### PR TITLE
Fix transparent option for RescaleMaintainAspectRatio

### DIFF
--- a/RescaleMaintainAspectNode.py
+++ b/RescaleMaintainAspectNode.py
@@ -61,7 +61,7 @@ def recaleimage(original_image,new_width,new_height,h_alignment,v_alignment,fill
     if fillcolor=="black":
         result_image = Image.new("RGB", (new_width, new_height), (0, 0, 0))
     elif fillcolor=="transparent":
-        result_image = Image.new("RGBA", (new_width, new_height), (0, 0, 0,255))
+        result_image = Image.new("RGBA", (new_width, new_height), (0, 0, 0, 0))
     else:
         result_image = Image.new("RGB", (new_width, new_height), (255, 255, 255))
 


### PR DESCRIPTION
Transparent option was filling with black for images. Now it properly fills with transparent pixels